### PR TITLE
perspective.el faces

### DIFF
--- a/kaolin-themes-lib.el
+++ b/kaolin-themes-lib.el
@@ -1903,7 +1903,10 @@
     (centaur-tabs-unselected-modified        (:background bg0 :foreground todo))
     (centaur-tabs-active-bar-face            (:background keyword))
     (centaur-tabs-modified-marker-selected   (:inherit 'centaur-tabs-selected :foreground keyword))
-    (centaur-tabs-modified-marker-unselected (:inherit 'centaur-tabs-unselected :foreground keyword))))
+    (centaur-tabs-modified-marker-unselected (:inherit 'centaur-tabs-unselected :foreground keyword))
+
+    ;; perspective.el
+    (persp-selected-face (:foreground kaolin-blue :weight 'bold))))
 
 (provide 'kaolin-themes-lib)
 


### PR DESCRIPTION
Adds (only) face for `perspective.el`: `persp-selected-face`.

This preserves the weight and uses `kaolin-blue` as it looks pleasing to me.

Not sure about the placement, but the tabs section seems closes to a workspace library like `perspective.el`.

This is the one thing that sometimes prevents me from using a kaolin theme over a doom theme, the glaring default blue.