### PR TITLE
feat: Add lexical-binding cookies to theme definition files

### DIFF
--- a/themes/kaolin-aurora-theme.el
+++ b/themes/kaolin-aurora-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-aurora-theme.el --- Kaolin meets polar lights.
+;;; kaolin-aurora-theme.el --- Kaolin meets polar lights. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-blossom-theme.el
+++ b/themes/kaolin-blossom-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-blossom-theme.el --- Kaolin theme based on orange and purple shades with dark pink background.
+;;; kaolin-blossom-theme.el --- Kaolin theme based on orange and purple shades with dark pink background. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-breeze-theme.el
+++ b/themes/kaolin-breeze-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-breeze-theme.el --- Light Kaolin theme with soft colors.
+;;; kaolin-breeze-theme.el --- Light Kaolin theme with soft colors. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-bubblegum-theme.el
+++ b/themes/kaolin-bubblegum-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-bubblegum-theme.el --- Kaolin colorful theme with dark blue background.
+;;; kaolin-bubblegum-theme.el --- Kaolin colorful theme with dark blue background. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-dark-theme.el
+++ b/themes/kaolin-dark-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-dark-theme.el --- A dark jade theme inspired by Sierra.vim
+;;; kaolin-dark-theme.el --- A dark jade theme inspired by Sierra.vim -*- lexical-binding: t; -*-
 
 (require 'kaolin-themes)
 

--- a/themes/kaolin-eclipse-theme.el
+++ b/themes/kaolin-eclipse-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-eclipse-theme.el --- Dark purple Kaolin theme variant
+;;; kaolin-eclipse-theme.el --- Dark purple Kaolin theme variant -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-galaxy-theme.el
+++ b/themes/kaolin-galaxy-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-galaxy-theme.el --- Bright theme based on one of the Sebastian Andaur arts.
+;;; kaolin-galaxy-theme.el --- Bright theme based on one of the Sebastian Andaur arts. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-light-theme.el
+++ b/themes/kaolin-light-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-light-theme.el --- Light Kaolin theme variant
+;;; kaolin-light-theme.el --- Light Kaolin theme variant -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-mono-dark-theme.el
+++ b/themes/kaolin-mono-dark-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-mono-dark-theme.el --- Almost monochrome dark green Kaolin theme.
+;;; kaolin-mono-dark-theme.el --- Almost monochrome dark green Kaolin theme. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-mono-light-theme.el
+++ b/themes/kaolin-mono-light-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-mono-light-theme.el --- almost monochrome light Kaolin theme
+;;; kaolin-mono-light-theme.el --- almost monochrome light Kaolin theme -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-ocean-theme.el
+++ b/themes/kaolin-ocean-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-ocean-theme.el --- Dark blue Kaolin theme
+;;; kaolin-ocean-theme.el --- Dark blue Kaolin theme -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-shiva-theme.el
+++ b/themes/kaolin-shiva-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-shiva-theme.el --- Kaolin theme with autumn colors and melanzane background
+;;; kaolin-shiva-theme.el --- Kaolin theme with autumn colors and melanzane background -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-temple-theme.el
+++ b/themes/kaolin-temple-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-temple-theme.el --- The terrestrial sphere imbues my spirit.
+;;; kaolin-temple-theme.el --- The terrestrial sphere imbues my spirit. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-valley-dark-theme.el
+++ b/themes/kaolin-valley-dark-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-valley-dark-theme.el --- Colorful Kaolin theme with brown background.
+;;; kaolin-valley-dark-theme.el --- Colorful Kaolin theme with brown background. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:

--- a/themes/kaolin-valley-light-theme.el
+++ b/themes/kaolin-valley-light-theme.el
@@ -1,4 +1,4 @@
-;;; kaolin-valley-light-theme.el --- light variant of Kaolin-valley-dark theme.
+;;; kaolin-valley-light-theme.el --- light variant of Kaolin-valley-dark theme. -*- lexical-binding: t; -*-
 ;;; Commentary:
 
 ;;; Code:


### PR DESCRIPTION
This adds `lexical-binding: t` cookies to the Kaolin theme definition files.

Why:
- Emacs 31 warns about `.el` files that do not declare their Lisp dialect
- these warnings can show up during package compilation/loading even when the themes themselves work correctly
- adding the cookie makes the intended dialect explicit and reduces warning noise

Scope:
- theme files only
- no intended functional changes

Why I think this is low risk:
- these files appear to be mostly theme definitions / declarations rather than code that depends on subtle dynamic-scoping behavior

Caveat:
- if any of these files intentionally rely on dynamic scope, then this should be reviewed more carefully before merging
- I did not make any behavioral changes beyond adding the file-local cookies

<img width="1188" height="80" alt="image" src="https://github.com/user-attachments/assets/4bf3b053-8587-4735-98df-83bddff7a0ff" />
